### PR TITLE
Use https URL when including MathJax javascript.

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <script src="demo/base62.js"></script>
         <script src="demo/demo.js"></script>
         <script type="text/javascript"
-            src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
+            src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML">
         </script>
         <script>
             document.addEventListener("DOMContentLoaded", function(event) {


### PR DESCRIPTION
When I view [your github.io](https://brettcvz.github.io/epicycles/) page none of the formulas render correctly, I just see the markup. This is happening because my web browser is blocking the insecure JS reference (http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML) from a secure page. You can see the fixed site: [here](https://sflanker.github.io/epicycles/). 